### PR TITLE
environment/developmentにURLを記入し、Blocked hostエラーを改善

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,7 @@ group :development, :test do
   gem "pry-byebug"
 
   gem "rspec-rails"
-  
+
   gem "bullet"
 end
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,8 @@
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
+  config.hosts << "beatboxer-collection.onrender.com"
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Make code changes take effect immediately without server restart.


### PR DESCRIPTION
Renderでデプロイした際にBlocked hostエラーが発生したので、environment/developmentにURLを記入し改善した