### PR TITLE
fix: config/environment/production.rbに送信元のgmailアカウントを追加

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,8 +1,6 @@
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
-  config.hosts << "beatboxer-collection.onrender.com"
-
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Make code changes take effect immediately without server restart.
@@ -48,7 +46,7 @@ Rails.application.configure do
       enable_starttls_auto: true,
       address: "smtp.gmail.com",
       port: "587",
-      domain: "beatboxer-collection.onrender.com",
+      domain: "localhost",
       authentication: "plain",
       user_name: ENV["GMAIL_USERNAME"],
       password: ENV["GMAIL_PASSWORD"],

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,7 +1,7 @@
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
-  # Settings specified here will take precedence over those in config/application.rb.
+  config.hosts << "beatboxer-collection.onrender.com"
 
   # Code is not reloaded between requests.
   config.enable_reloading = false
@@ -57,7 +57,20 @@ Rails.application.configure do
   # config.action_mailer.raise_delivery_errors = false
 
   # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: "example.com" }
+  config.action_mailer.default_url_options = { host: "beatboxer-collection.onrender.com" }
+
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.smtp_settings = {
+      enable_starttls_auto: true,
+      address: "smtp.gmail.com",
+      port: "587",
+      domain: "beatboxer-collection.onrender.com",
+      authentication: "plain",
+      user_name: ENV["GMAIL_USERNAME"],
+      password: ENV["GMAIL_PASSWORD"],
+      password: ENV["GMAIL_APPLICATION_PASSWORD"]
+  }
 
   # Specify outgoing SMTP server. Remember to add smtp/* credentials via rails credentials:edit.
   # config.action_mailer.smtp_settings = {


### PR DESCRIPTION
本番環境でユーザー登録後、ステータス500が発生した。
(paramsに問題はなかったがusers/createのuser.saveで処理が止まった模様。)
ひとまず、config/environment/production.rbに、確認メールの送信元であるgmailアカウントを追記していなかったので記載した
一度これで挙動を確認する。