### PR TITLE
fix: ユーザー認証に関して記載を変更

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,7 +18,7 @@ class UsersController < ApplicationController
 
   def activate
     if (@user = User.load_from_activation_token(params[:id]))
-      @user.active!
+      @user.update(activation_state: "active")
       flash[:notice] = "ユーザー登録が完了しました"
       redirect_to login_path
     else


### PR DESCRIPTION
users#activateにてユーザーの仮登録を登録済みに変更する際、テーブルのデータをpendingからactiveに変更する必要があるが、参考記事では@user.active!という手法を使用していた。
しかし、renderは500番のステータスを返しており、結果としては.activeというメソッドが見つからないことに起因していた。

改善点：users#activateの@user.active!→updateアクションで書き換える形に変更