### PR TITLE
fix: アクティベーションされていないユーザーを弾く処理を記載

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -6,10 +6,16 @@ class UserSessionsController < ApplicationController
     def create
       user = login(params[:email], params[:password])
       if user
-        flash[:notice] = "ログインしました"
-        redirect_to root_path
+        if user.activation_state == "active"
+          flash[:notice] = "ログインしました"
+          redirect_to root_path
+        else
+          logout
+          flash.now[:alert] = "アカウントが有効化されていません。メールをご確認ください。"
+          render :new, status: :unauthorized
+        end
       else
-        flash.now[:alert] = "ログインに失敗しました"
+        flash.now[:alert] = "入力情報が間違っているか、アカウントが作成されていません。"
         render :new, status: :unprocessable_entity
       end
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -17,8 +17,8 @@ class UsersController < ApplicationController
   end
 
   def activate
-    if (@user = User.load_from_activation_token(params[:id]))
-      @user.update(activation_state: "active")
+    if (user = User.load_from_activation_token(params[:id]))
+      user.update(activation_state: "active")
       flash[:notice] = "ユーザー登録が完了しました"
       redirect_to login_path
     else


### PR DESCRIPTION
経緯： activation_stateがpending(仮登録状態)でもログインできてしまった。
改善点：user_session_controllerのcreateアクションでifをネストすることで改善を図った。
　　　　　└activation_stateがactiveの場合は、ログイン状態を保持し、トップページに遷移する
　　　　　└activation_stateがactiveでない場合は、ログアウトを実行し、ログインページをrenderする